### PR TITLE
feat: make CLI detection notifications configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,10 @@ require("claude-code").setup({
   -- Command settings
   command = "claude",        -- Command used to launch Claude Code
   cli_path = nil,            -- Optional custom path to Claude command-line tool executable (e.g., "/custom/path/to/claude")
+  -- CLI detection notification settings
+  cli_notification = {
+    enabled = false,         -- Show CLI detection notifications on startup (disabled by default)
+  },
   -- Command variants
   command_variants = {
     -- Conversation management

--- a/lua/claude-code/config.lua
+++ b/lua/claude-code/config.lua
@@ -180,6 +180,10 @@ M.default_config = {
     message = 'Claude Code plugin loaded', -- Custom startup message
     level = vim.log.levels.INFO, -- Log level for startup notification
   },
+  -- CLI detection notification settings
+  cli_notification = {
+    enabled = false, -- Show CLI detection notifications (disabled by default)
+  },
 }
 
 --- Validate window configuration
@@ -557,8 +561,8 @@ function M.parse_config(user_config, silent)
     local detected_cli = detect_claude_cli(custom_path)
     config.command = detected_cli or 'claude'
 
-    -- Notify user about the CLI selection
-    if not silent then
+    -- Notify user about the CLI selection (only if cli_notification is enabled)
+    if not silent and config.cli_notification.enabled then
       if custom_path then
         if detected_cli == custom_path then
           vim.notify('Claude Code: Using custom CLI at ' .. custom_path, vim.log.levels.INFO)


### PR DESCRIPTION
Add new cli_notification.enabled config option (defaults to false) to control whether the plugin shows notifications about Claude Code installation detection on startup. This prevents the notification from appearing by default while still allowing users to enable it if desired.

🤖 Generated with [Claude Code](https://claude.ai/code)


# Pull Request

## Description

Please provide a clear description of what this PR does and why it should be merged.

## Type of Change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Checklist

Please check all that apply:

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have tested with the actual Claude Code command-line tool
- [ ] I have tested in different environments (if applicable)

## Screenshots (if applicable)

Add screenshots to help explain your changes if they include visual elements.

## Additional Notes

Add any other context about the PR here.

